### PR TITLE
Fix ranking display for ties

### DIFF
--- a/src/pages/home.py
+++ b/src/pages/home.py
@@ -166,6 +166,11 @@ _RANK_ICONS = {
 
 def _leaderboard_table(title, data_counter, summaries, row_type, deck_rows=False, deck_map=None):
     rows = []
+    # Track the previous point total so tied scores receive the same rank.  The
+    # leaderboard itself is sorted by badge count and then point total, but
+    # ranking is based solely on points.
+    prev_points = None
+    rank = 0
     for i, (name, count, points) in enumerate(data_counter):
         idx = f"{row_type}-{title}-{i}-{name}".lower().replace(' ', '')
         toggle_id = {'type': f'lb-toggle', 'index': idx}
@@ -175,8 +180,15 @@ def _leaderboard_table(title, data_counter, summaries, row_type, deck_rows=False
             label = components.deck_label.create_label(deck)
         else:
             label = name
+
+        if points != prev_points:
+            rank = i + 1
+        prev_points = points
+
+        rank_display = html.I(className=f'fas fa-{_RANK_ICONS[rank]}') if rank in _RANK_ICONS else rank
+
         rows.append(html.Tr([
-            html.Td(html.I(className=f'fas fa-{_RANK_ICONS[i+1]}') if i+1 in _RANK_ICONS else i+1, className='text-center align-middle w-0 text-dark'),
+            html.Td(rank_display, className='text-center align-middle w-0 text-dark'),
             html.Td(html.A(label, id=toggle_id, n_clicks=0), className='align-middle'),
             html.Td(count, className='text-center align-middle'),
             html.Td(points, className='text-center align-middle'),


### PR DESCRIPTION
## Summary
- adjust leaderboard rendering to consider ties by points rather than badge count

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687252f0ef08832d9a7dada3f8a645b8